### PR TITLE
Release/2.7.7

### DIFF
--- a/apps/site/src/app/documentation.config.ts
+++ b/apps/site/src/app/documentation.config.ts
@@ -7,7 +7,7 @@ import {
   provideDocumentationMeta,
   provideFooterNavigation,
   provideHeader,
-  provideHeaderMediaLinks,
+  provideHeaderMediaLinks, provideHeaderSearch,
   provideLanguage,
   provideLogo,
   provideNavigation,
@@ -35,6 +35,7 @@ export const DOCUMENTATION_CONFIGURATION = {
       range: { start: 2, end: 6 },
     }),
     provideHeader(
+      provideHeaderSearch(true),
       // provideHeaderNavigation([{
       //   link: '/docs/what-is-mrender',
       //   active: '/docs/what-is-mrender',

--- a/apps/site/src/app/documentation.config.ts
+++ b/apps/site/src/app/documentation.config.ts
@@ -35,7 +35,7 @@ export const DOCUMENTATION_CONFIGURATION = {
       range: { start: 2, end: 6 },
     }),
     provideHeader(
-      provideHeaderSearch(true),
+      provideHeaderSearch(false),
       // provideHeaderNavigation([{
       //   link: '/docs/what-is-mrender',
       //   active: '/docs/what-is-mrender',

--- a/apps/site/src/app/home.config.ts
+++ b/apps/site/src/app/home.config.ts
@@ -1,5 +1,5 @@
 import {
-  provideHeader,
+  provideHeader, provideHeaderSearch,
   provideHeaderMediaLinks,
   provideHeaderNavigation,
   provideHero,
@@ -51,6 +51,7 @@ export const HOME_CONFIGURATION = {
       description: 'Enhance your documents with Angular components. Embed custom elements directly into the text for an intuitive representation of complex information.',
     }]),
     provideHeader(
+      provideHeaderSearch(true),
       provideHeaderNavigation([
         {
           link: '/introduction/what-is-mrender',

--- a/apps/site/src/app/home.config.ts
+++ b/apps/site/src/app/home.config.ts
@@ -51,7 +51,7 @@ export const HOME_CONFIGURATION = {
       description: 'Enhance your documents with Angular components. Embed custom elements directly into the text for an intuitive representation of complex information.',
     }]),
     provideHeader(
-      provideHeaderSearch(true),
+      provideHeaderSearch(false),
       provideHeaderNavigation([
         {
           link: '/introduction/what-is-mrender',

--- a/libs/m-render/package.json
+++ b/libs/m-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foblex/m-render",
-  "version": "2.7.4",
+  "version": "2.7.5",
   "description": "MRender is a static site generator designed for creating fast and user-friendly documentation sites based on Markdown files. MarkEngine supports extended Markdown syntax and can render Angular components directly from Markdown files.",
   "author": "Siarhei Huzarevich",
   "license": "MIT",

--- a/libs/m-render/package.json
+++ b/libs/m-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foblex/m-render",
-  "version": "2.7.5",
+  "version": "2.7.6",
   "description": "MRender is a static site generator designed for creating fast and user-friendly documentation sites based on Markdown files. MarkEngine supports extended Markdown syntax and can render Angular components directly from Markdown files.",
   "author": "Siarhei Huzarevich",
   "license": "MIT",

--- a/libs/m-render/package.json
+++ b/libs/m-render/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foblex/m-render",
-  "version": "2.7.6",
+  "version": "2.7.7",
   "description": "MRender is a static site generator designed for creating fast and user-friendly documentation sites based on Markdown files. MarkEngine supports extended Markdown syntax and can render Angular components directly from Markdown files.",
   "author": "Siarhei Huzarevich",
   "license": "MIT",

--- a/libs/m-render/src/assets/styles/_icons.scss
+++ b/libs/m-render/src/assets/styles/_icons.scss
@@ -1,66 +1,3 @@
-//.vpi-align-left {
-//  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M21 6H3M15 12H3M17 18H3'/%3E%3C/svg%3E");
-//}
-//
-//.vpi-arrow-right,
-//.vpi-arrow-down,
-//.vpi-arrow-left,
-//.vpi-arrow-up {
-//  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M5 12h14M12 5l7 7-7 7'/%3E%3C/svg%3E");
-//}
-//
-//.vpi-chevron-right,
-//.vpi-chevron-down,
-//.vpi-chevron-left,
-//.vpi-chevron-up {
-//  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='m9 18 6-6-6-6'/%3E%3C/svg%3E");
-//}
-//
-//.vpi-chevron-down,
-//.vpi-arrow-down {
-//  transform: rotate(90deg);
-//}
-//
-//.vpi-chevron-left,
-//.vpi-arrow-left {
-//  transform: rotate(180deg);
-//}
-//
-//.vpi-chevron-up,
-//.vpi-arrow-up {
-//  transform: rotate(-90deg);
-//}
-//
-//.vpi-plus {
-//  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M5 12h14M12 5v14'/%3E%3C/svg%3E");
-//}
-//
-//.vpi-more-horizontal {
-//  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='1'/%3E%3Ccircle cx='19' cy='12' r='1'/%3E%3Ccircle cx='5' cy='12' r='1'/%3E%3C/svg%3E");
-//}
-//
-//.vpi-languages {
-//  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='m5 8 6 6M4 14l6-6 2-3M2 5h12M7 2h1M22 22l-5-10-5 10M14 18h6'/%3E%3C/svg%3E");
-//}
-//
-
-//
-//.vpi-search {
-//  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.3-4.3'/%3E%3C/svg%3E");
-//}
-//
-//.vpi-layout-list {
-//  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Crect width='7' height='7' x='3' y='3' rx='1'/%3E%3Crect width='7' height='7' x='3' y='14' rx='1'/%3E%3Cpath d='M14 4h7M14 9h7M14 15h7M14 20h7'/%3E%3C/svg%3E");
-//}
-//
-//.vpi-delete {
-//  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='M20 5H9l-7 7 7 7h11a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2ZM18 9l-6 6M12 9l6 6'/%3E%3C/svg%3E");
-//}
-//
-//.vpi-corner-down-left {
-//  --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Cpath d='m9 10-5 5 5 5'/%3E%3Cpath d='M20 4v7a4 4 0 0 1-4 4H4'/%3E%3C/svg%3E");
-//}
-
 :root {
   --copy-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='rgba(128,128,128,1)' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Crect width='8' height='4' x='8' y='2' rx='1' ry='1'/%3E%3Cpath d='M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2'/%3E%3C/svg%3E");
 }
@@ -77,6 +14,10 @@
   &:hover {
     color: var(--primary-text);
   }
+}
+
+.search {
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.6' viewBox='0 0 24 24'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.3-4.3'/%3E%3C/svg%3E");
 }
 
 .heart {
@@ -128,8 +69,6 @@
   mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z'/%3E%3C/svg%3E");
 }
 
-
-//
 .sun {
   mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='4'/%3E%3Cpath d='M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41'/%3E%3C/svg%3E");
 }

--- a/libs/m-render/src/lib/common/components/f-search-button/f-search-button.component.html
+++ b/libs/m-render/src/lib/common/components/f-search-button/f-search-button.component.html
@@ -1,0 +1,1 @@
+<a class="f-icon search" [routerLink]="[]" fragment="search"></a>

--- a/libs/m-render/src/lib/common/components/f-search-button/f-search-button.component.scss
+++ b/libs/m-render/src/lib/common/components/f-search-button/f-search-button.component.scss
@@ -1,0 +1,13 @@
+.f-icon {
+  display: block;
+  width: 20px;
+  height: 20px;
+  margin-left: 8px;
+  color: var(--sponsor);
+  cursor: pointer;
+  transition: transform 0.2s ease;
+
+  &:hover {
+    transform: scale(1.1);
+  }
+}

--- a/libs/m-render/src/lib/common/components/f-search-button/f-search-button.component.ts
+++ b/libs/m-render/src/lib/common/components/f-search-button/f-search-button.component.ts
@@ -1,0 +1,18 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+} from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'f-search-button',
+  templateUrl: './f-search-button.component.html',
+  styleUrls: ['./f-search-button.component.scss'],
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    RouterLink,
+  ],
+})
+export class FSearchButtonComponent {
+}

--- a/libs/m-render/src/lib/common/components/index.ts
+++ b/libs/m-render/src/lib/common/components/index.ts
@@ -1,3 +1,5 @@
+export * from './f-search-button/f-search-button.component';
+
 export * from './f-checkbox/f-checkbox.component';
 
 export * from './f-radio-button/f-radio-button.component';

--- a/libs/m-render/src/lib/common/domain/configuration-providers/index.ts
+++ b/libs/m-render/src/lib/common/domain/configuration-providers/index.ts
@@ -1,4 +1,5 @@
 export * from './provide-header';
+export * from './provide-header-search';
 export * from './provide-header-media-links';
 export * from './provide-header-navigation';
 export * from './provide-language';

--- a/libs/m-render/src/lib/common/domain/configuration-providers/provide-header-search.ts
+++ b/libs/m-render/src/lib/common/domain/configuration-providers/provide-header-search.ts
@@ -1,0 +1,7 @@
+import { IHeaderConfiguration } from './provide-header';
+
+export function provideHeaderSearch(search?: boolean): Partial<IHeaderConfiguration> {
+  return {
+    search,
+  };
+}

--- a/libs/m-render/src/lib/common/domain/configuration-providers/provide-header.ts
+++ b/libs/m-render/src/lib/common/domain/configuration-providers/provide-header.ts
@@ -1,5 +1,4 @@
 import { IHeaderMenuLink, ISocialLink } from '../../components';
-import { InjectionToken } from '@angular/core';
 
 export function provideHeader(
   ...configuration: Partial<IHeaderConfiguration>[]
@@ -11,13 +10,14 @@ export function provideHeader(
 
 export interface IHeaderConfiguration {
 
+  search?: boolean;
+
   navigation?: IHeaderMenuLink[];
 
   mediaLinks?: ISocialLink[];
 }
 
 export interface IHasHeaderConfiguration {
+
   header?: IHeaderConfiguration;
 }
-
-export const HEADER_CONFIGURATION = new InjectionToken<IHasHeaderConfiguration>('HEADER_CONFIGURATION');

--- a/libs/m-render/src/lib/documentation-page/components/header/header.component.html
+++ b/libs/m-render/src/lib/documentation-page/components/header/header.component.html
@@ -1,9 +1,17 @@
 <button hamburger-button></button>
 <div class="title text-ellipsis">{{ title }}</div>
-<inline-menu/>
+<div class="flex-space"></div>
 <!--<npm-version/>-->
-<div class="divider"></div>
+@if (config?.navigation) {
+  <inline-menu/>
+  <div class="divider"></div>
+}
+
 <button theme-button></button>
 <div class="divider"></div>
 <f-social-links/>
+@if (config?.search) {
+  <div class="divider"></div>
+  <f-search-button/>
+}
 

--- a/libs/m-render/src/lib/documentation-page/components/header/header.component.ts
+++ b/libs/m-render/src/lib/documentation-page/components/header/header.component.ts
@@ -5,6 +5,7 @@ import {
 import { HamburgerButtonComponent } from './hamburger-button';
 import { DocumentationStore } from '../../services';
 import {
+  FSearchButtonComponent,
   FSocialLinksComponent,
   InlineMenuComponent,
 } from '../../../common';
@@ -21,8 +22,11 @@ import { ThemeButtonComponent } from '../../../theme';
     FSocialLinksComponent,
     ThemeButtonComponent,
     InlineMenuComponent,
+    FSearchButtonComponent,
   ],
 })
 export class HeaderComponent {
   protected title = inject(DocumentationStore).getTitle();
+
+  protected config = inject(DocumentationStore).getHeader();
 }

--- a/libs/m-render/src/lib/documentation-page/components/markdown-container/f-markdown/f-markdown-renderer.component.ts
+++ b/libs/m-render/src/lib/documentation-page/components/markdown-container/f-markdown/f-markdown-renderer.component.ts
@@ -71,7 +71,7 @@ export class FMarkdownRendererComponent implements OnInit, OnDestroy {
         startWith(null),
         debounceTime(50),
         switchMap(() =>
-          this._markdown.parse(
+          this._markdown.parseUrl(
             this._provider.getMarkdownUrl(this._markdownPath),
           ),
         ),

--- a/libs/m-render/src/lib/documentation-page/components/markdown-container/f-markdown/markdown/markdown.service.ts
+++ b/libs/m-render/src/lib/documentation-page/components/markdown-container/f-markdown/markdown/markdown.service.ts
@@ -39,9 +39,19 @@ export class MarkdownService {
       .use(...new ParseAngularExampleWithCodeLinks().render());
   }
 
-  public parse(src: string): Observable<SafeHtml> {
+  public parseUrl(src: string): Observable<SafeHtml> {
     return this._httpClient.get(src, { responseType: 'text' }).pipe(take(1), catchError(() => of(''))).pipe(
       switchMap((text) => of(this._markdown.render(text))),
+      switchMap((x) => of(this._cleanupEmptyParagraphs(x))),
+      switchMap((x) => of(this._cleanupWasteParagraphFromExampleView(x))),
+      switchMap((x) => of(this._cleanupWasteParagraphFromPreviewGroup(x))),
+      switchMap((x) => of(this._normalizeLinks(x))),
+      switchMap((x) => of(this._domSanitizer.bypassSecurityTrustHtml(x))),
+    );
+  }
+
+  public parseText(value: string): Observable<SafeHtml> {
+    return of(this._markdown.render(value)).pipe(
       switchMap((x) => of(this._cleanupEmptyParagraphs(x))),
       switchMap((x) => of(this._cleanupWasteParagraphFromExampleView(x))),
       switchMap((x) => of(this._cleanupWasteParagraphFromPreviewGroup(x))),

--- a/libs/m-render/src/lib/documentation-page/components/markdown-container/f-markdown/markdown/markdown.service.ts
+++ b/libs/m-render/src/lib/documentation-page/components/markdown-container/f-markdown/markdown/markdown.service.ts
@@ -23,7 +23,7 @@ export class MarkdownService {
   private readonly _httpClient = inject(HttpClient);
   private readonly _domSanitizer = inject(DomSanitizer);
   private readonly _router = inject(Router);
-  private readonly _provider = inject(F_PREVIEW_NAVIGATION_PROVIDER);
+  private readonly _provider = inject(F_PREVIEW_NAVIGATION_PROVIDER, {optional: true});
 
   constructor() {
     this._markdown
@@ -35,7 +35,7 @@ export class MarkdownService {
       .use(...new ParseAlerts().render(EMarkdownContainerType.ALERT_DANGER, this._markdown))
       .use(...new ParseAlerts().render(EMarkdownContainerType.ALERT_SUCCESS, this._markdown))
       .use(...new ParseGroupedCodeItems().render())
-      .use(...new ParsePreviewGroup(this._provider.getNavigation()).render())
+      .use(...new ParsePreviewGroup(this._provider?.getNavigation() || []).render())
       .use(...new ParseAngularExampleWithCodeLinks().render());
   }
 

--- a/libs/m-render/src/lib/home-page/components/f-home-page-header/f-home-page-header.component.html
+++ b/libs/m-render/src/lib/home-page/components/f-home-page-header/f-home-page-header.component.html
@@ -6,5 +6,9 @@
 
   <div class="flex-space"></div>
   <button theme-button aria-label="Change theme"></button>
+  @if (config?.search) {
+    <div class="divider"></div>
+    <f-search-button/>
+  }
 </div>
 

--- a/libs/m-render/src/lib/home-page/components/f-home-page-header/f-home-page-header.component.scss
+++ b/libs/m-render/src/lib/home-page/components/f-home-page-header/f-home-page-header.component.scss
@@ -41,3 +41,12 @@
     padding: 0 64px;
   }
 }
+
+.divider {
+  margin-right: 8px;
+  margin-left: 8px;
+  width: 1px;
+  height: 24px;
+  background-color: var(--divider-color);
+  content: "";
+}

--- a/libs/m-render/src/lib/home-page/components/f-home-page-header/f-home-page-header.component.ts
+++ b/libs/m-render/src/lib/home-page/components/f-home-page-header/f-home-page-header.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { HomeStore } from '../../services';
 import { ThemeButtonComponent } from '../../../theme';
+import { FSearchButtonComponent } from '../../../common';
 
 @Component({
   selector: 'header[f-home-page-header]',
@@ -9,9 +10,12 @@ import { ThemeButtonComponent } from '../../../theme';
   standalone: true,
   imports: [
     ThemeButtonComponent,
+    FSearchButtonComponent,
   ],
 })
 export class FHomePageHeaderComponent {
   protected logo = inject(HomeStore).getLogo();
   protected title = inject(HomeStore).getTitle();
+
+  protected config = inject(HomeStore).getHeader();
 }


### PR DESCRIPTION
This pull request introduces a configurable search button to the header components of both the documentation and home pages, controlled via a new `search` option in the header configuration. It also adds a new search button component with associated styles and updates the Markdown service to separate parsing of URLs and raw text. Additionally, the version of `@foblex/m-render` is incremented, and some code cleanup and style improvements are made.

**Header Search Feature**

* Added a new `search` property to the header configuration (`IHeaderConfiguration`) and a `provideHeaderSearch` provider to enable or disable the search button in the header. [[1]](diffhunk://#diff-cf239cbcb4907c0a4fb5185666457c1ce8916f5d225b7d3dd92372cb832deb64R13-L23) [[2]](diffhunk://#diff-26b53349fe652b1dad93cc5cb7f92962346aafad475759258cc90227d97e25c4R1-R7) [[3]](diffhunk://#diff-7c7457f18e9939f456951b64a8ba4847641bafcaba6481f1addca410cebba27dR2)
* Updated documentation and home page configs to use `provideHeaderSearch(false)` and pass the `search` property to their headers. [[1]](diffhunk://#diff-7e96eb6bf4f8c7907b547fd3de5cfe0458db0aa3f5d5dfca4f10eafe3b8e6f90L10-R10) [[2]](diffhunk://#diff-7e96eb6bf4f8c7907b547fd3de5cfe0458db0aa3f5d5dfca4f10eafe3b8e6f90R38) [[3]](diffhunk://#diff-86e4c5dfe4579a1cf70ec6a1e94f109440460cf8d448a7fba7005efc4518128eL2-R2) [[4]](diffhunk://#diff-86e4c5dfe4579a1cf70ec6a1e94f109440460cf8d448a7fba7005efc4518128eR54)
* Modified header components to conditionally display the new search button based on the `search` property in the config. [[1]](diffhunk://#diff-64749fd0db0b554dadd193240bedaed7639a879cbc0d5a9679ae92661a45c741L3-R16) [[2]](diffhunk://#diff-9e227cba4f7ee89186b1581662bcb30eccb0a5a6f1b208ea397820c21798faefR8) [[3]](diffhunk://#diff-9e227cba4f7ee89186b1581662bcb30eccb0a5a6f1b208ea397820c21798faefR25-R31) [[4]](diffhunk://#diff-914ad882f769e6706dabaf13b070cf1e3ce6ee14a43b3474bd562f45d3cad5a8R9-R12) [[5]](diffhunk://#diff-cfaed5fc1317b949a43fb81e35cff95bcbd37fabef1c12c55a56eb67f4b27234R4) [[6]](diffhunk://#diff-cfaed5fc1317b949a43fb81e35cff95bcbd37fabef1c12c55a56eb67f4b27234R13-R20)

**Search Button Component**

* Added a new standalone `FSearchButtonComponent` with its template, styles, and export, and included it in the relevant header components. [[1]](diffhunk://#diff-af4d608d6d6591b9f32bd43d47c697c4291847ae817a7df42b6a713e9697cd3aR1) [[2]](diffhunk://#diff-20504ae6364868130c540f95cdcf92fae4224360b1d026f0d011c9943075725fR1-R13) [[3]](diffhunk://#diff-cf6d6546fc0a9f5d1cdb65ca8abe097b130afbe31a364a18eed2b5a68d475bfeR1-R18) [[4]](diffhunk://#diff-b6380227916efef610bd8951f3e2f124f4aa03e4838d0ba95234960ad3a299e7R1-R2)

**Markdown Service Improvements**

* Refactored the Markdown service to distinguish between parsing from a URL (`parseUrl`) and parsing from a raw string (`parseText`), and made the preview navigation provider optional. [[1]](diffhunk://#diff-97d2489b2d3a2951087852429fdf35aa71df8de9ac80d59a0bd2d6fc507c3d58L74-R74) [[2]](diffhunk://#diff-d068666b8e9573c9d26315747d016e27f33fc490bec0ca02c20ebd22e2fec9a4L26-R26) [[3]](diffhunk://#diff-d068666b8e9573c9d26315747d016e27f33fc490bec0ca02c20ebd22e2fec9a4L38-R42) [[4]](diffhunk://#diff-d068666b8e9573c9d26315747d016e27f33fc490bec0ca02c20ebd22e2fec9a4R53-R62)

**Styling and Cleanup**

* Added and improved styles for the search icon and header dividers, and removed commented-out legacy icon styles. [[1]](diffhunk://#diff-9f1d392ea84df6d360431aefcd104363780ffaccab9edc55b56654b17d34accdL1-L63) [[2]](diffhunk://#diff-9f1d392ea84df6d360431aefcd104363780ffaccab9edc55b56654b17d34accdR19-R22) [[3]](diffhunk://#diff-9f1d392ea84df6d360431aefcd104363780ffaccab9edc55b56654b17d34accdL131-L132) [[4]](diffhunk://#diff-ea6441167551600190138b07f1f2dc5b5c9a32a646b5fe5958fb8a1a5b7dfa9fR44-R52)

**Package Version**

* Bumped the version of `@foblex/m-render` from `2.7.4` to `2.7.7`.
